### PR TITLE
[Halo96 v2] Add numpad 5 to leds in position_mode

### DIFF
--- a/keyboards/nuphy/halo96_v2/ansi/keymaps/via/rgb_matrix_user.inc
+++ b/keyboards/nuphy/halo96_v2/ansi/keymaps/via/rgb_matrix_user.inc
@@ -18,14 +18,14 @@ static bool game_mode(effect_params_t* params) {
     rgb_matrix_set_color(0, rgb.r, rgb.g, rgb.b);       // ESC
 
     rgb_matrix_set_color(39, rgb.r, rgb.g, rgb.b);      // W
-    rgb_matrix_set_color(56, rgb.r, rgb.g, rgb.b);      // D
+    rgb_matrix_set_color(56, rgb.r, rgb.g, rgb.b);      // A
     rgb_matrix_set_color(57, rgb.r, rgb.g, rgb.b);      // S
-    rgb_matrix_set_color(58, rgb.r, rgb.g, rgb.b);      // A
+    rgb_matrix_set_color(58, rgb.r, rgb.g, rgb.b);      // D
 
     rgb_matrix_set_color(83, rgb.r, rgb.g, rgb.b);      // up
-    rgb_matrix_set_color(94, rgb.r, rgb.g, rgb.b);      // right
+    rgb_matrix_set_color(94, rgb.r, rgb.g, rgb.b);      // left
     rgb_matrix_set_color(95, rgb.r, rgb.g, rgb.b);      // down
-    rgb_matrix_set_color(96, rgb.r, rgb.g, rgb.b);      // left
+    rgb_matrix_set_color(96, rgb.r, rgb.g, rgb.b);      // right
 
     return rgb_matrix_check_finished_leds(led_max);
 }
@@ -42,6 +42,7 @@ static bool position_mode(effect_params_t* params) {
 
     rgb_matrix_set_color(59, rgb.r, rgb.g, rgb.b);      // F
     rgb_matrix_set_color(62, rgb.r, rgb.g, rgb.b);      // J
+    rgb_matrix_set_color(69, rgb.r, rgb.g, rgb.b);      // 5
     rgb_matrix_set_color(83, rgb.r, rgb.g, rgb.b);      // up
 
     return rgb_matrix_check_finished_leds(led_max);


### PR DESCRIPTION
## Description
Hi NuPhy team,

I recently bought a Halo96 v2 and one of the features I was excited about was the illuminated homing keys.
Sadly the numpad 5 key does not light up as the F, J and up arrow, although on your website we can see the 5 key also beautifully lit in the pictures.

I opened this PR in hopes of fixing this issue.

I tested the updated firmware on my keyboard and everything seems to be working fine.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Test
![IMG_3211](https://github.com/user-attachments/assets/d16747eb-6e33-4790-9739-1c49086ab85d)
