### PR TITLE
Update ansi.c to use eeconfig_read_user_datablock for air75_v2 (and maybe other versions?)

### DIFF
--- a/keyboards/nuphy/air75_v2/ansi/ansi.c
+++ b/keyboards/nuphy/air75_v2/ansi/ansi.c
@@ -420,7 +420,7 @@ void timer_pro(void) {
  * @brief  londing eeprom data.
  */
 void londing_eeprom_data(void) {
-    eeconfig_read_kb_datablock(&user_config);
+    eeconfig_read_user_datablock(&user_config);
     if (user_config.default_brightness_flag != 0xA5) {
         /* first power on, set rgb matrix brightness at middle level*/
         rgb_matrix_sethsv(255, 255, RGB_MATRIX_MAXIMUM_BRIGHTNESS - RGB_MATRIX_VAL_STEP * 2);


### PR DESCRIPTION
This makes it compile ok for me. I am not entirely sure why, but I think it makes sense to load the config using this function, same as the halo95 code? https://github.com/venetanji/qmk_firmware/blob/ec8b9fb2cdc0e7d97166e4edd57ae5c52bc3cdaa/keyboards/nuphy/halo96_v2/ansi/ansi.c#L716


## Description

Got the keyboard yesterday, I managed to compile working firmware with this change.
Qmk compile threw an error about `eeconfig_read_kb_datablock`

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

Fixes compilation errors for air75_v2



